### PR TITLE
Fixing "autoGenerateNodeIds"to work with more than 10 nodes.

### DIFF
--- a/config.go
+++ b/config.go
@@ -100,7 +100,7 @@ func prepareAerospikeConfig(peersList []string) (err error) {
 			// Set node-id
 			if autoGenerateNodeIds == "true" {
 				if podName != "" {
-					r, _ := regexp.Compile("([^-]+$)")
+					r := regexp.MustCompile("([^-]+$)")
 					fileContent += "\tnode-id " + nodeIDPrefix + r.FindString(podName) + "\n"
 				}
 			}

--- a/config.go
+++ b/config.go
@@ -100,7 +100,8 @@ func prepareAerospikeConfig(peersList []string) (err error) {
 			// Set node-id
 			if autoGenerateNodeIds == "true" {
 				if podName != "" {
-					fileContent += "\tnode-id " + nodeIDPrefix + podName[len(podName)-1:] + "\n"
+					r, _ := regexp.Compile("([^-]+$)")
+					fileContent += "\tnode-id " + nodeIDPrefix + r.FindString(podName) + "\n"
 				}
 			}
 


### PR DESCRIPTION
Fixing generation of the nodeID because now if you have a cluster with more than 10 nodes it will not works. For example, the pod name aerospike-11 will be the same id as pod aerospike-1, both will have id aerospike-1